### PR TITLE
todoのtitle更新にキーイベントを追加

### DIFF
--- a/src/hooks/useMutateTodo.ts
+++ b/src/hooks/useMutateTodo.ts
@@ -1,0 +1,34 @@
+import { api } from "@/utils/api"
+
+export const useMutateTodo = () => {
+  const { refetch } = api.todo.fetch.useQuery()
+
+  const handleSuccess = () => {
+    refetch().catch((error) => {
+      console.error("An error occurred during refetch: ", error)
+    })
+  }
+
+  const createTodoMutation = api.todo.create.useMutation({
+    onSuccess: handleSuccess,
+  })
+
+  const updateTitleMutation = api.todo.updateTitle.useMutation({
+    onSuccess: handleSuccess,
+  })
+
+  const updateIsCompletedMutation = api.todo.updateIsCompleted.useMutation({
+    onSuccess: handleSuccess,
+  })
+
+  const deleteTodoMutation = api.todo.delete.useMutation({
+    onSuccess: handleSuccess,
+  })
+
+  return {
+    createTodoMutation,
+    updateTitleMutation,
+    updateIsCompletedMutation,
+    deleteTodoMutation,
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent, FormEvent, MouseEvent } from "react"
 import { useState } from "react"
 
+import { useMutateTodo } from "@/hooks/useMutateTodo"
 import { api } from "@/utils/api"
 
 const HomePage = () => {
@@ -12,46 +13,16 @@ const HomePage = () => {
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 5
 
-  const { isLoading, error, data, refetch } = api.todo.fetch.useQuery()
-
-  const createMutation = api.todo.create.useMutation({
-    onSuccess: () => {
-      refetch().catch((error) => {
-        console.error("An error occurred during refetch: ", error)
-      })
-    },
-  })
-
-  const updateTitleMutation = api.todo.updateTitle.useMutation({
-    onSuccess: () => {
-      refetch().catch((error) => {
-        console.error("An error occurred during refetch: ", error)
-      })
-    },
-  })
-
-  const updateIsCompletedMutation = api.todo.updateIsCompleted.useMutation({
-    onSuccess: () => {
-      refetch().catch((error) => {
-        console.error("An error occurred during refetch: ", error)
-      })
-    },
-  })
-
-  const deleteMutation = api.todo.delete.useMutation({
-    onSuccess: () => {
-      refetch().catch((error) => {
-        console.error("An error occurred during refetch: ", error)
-      })
-    },
-  })
+  const { data } = api.todo.fetch.useQuery()
+  const { createTodoMutation, updateTitleMutation, updateIsCompletedMutation, deleteTodoMutation } =
+    useMutateTodo()
 
   const handleCreateTodo = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (title.trim() === "") {
       return
     }
-    createMutation
+    createTodoMutation
       .mutateAsync({ title })
       .then(() => {
         setTitle("")
@@ -93,7 +64,7 @@ const HomePage = () => {
 
   const handleDeleteClick = (id: string) => {
     if (confirm("削除してもよろしいでしょうか？")) {
-      deleteMutation.mutateAsync({ id }).catch((error) => {
+      deleteTodoMutation.mutateAsync({ id }).catch((error) => {
         console.error("An error occurred during deletion: ", error)
       })
       if (currentItems?.length === 1) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, FormEvent, MouseEvent } from "react"
+import type { ChangeEvent, FormEvent, KeyboardEvent, MouseEvent } from "react"
 import { useState } from "react"
 
 import { useMutateTodo } from "@/hooks/useMutateTodo"
@@ -60,6 +60,15 @@ const HomePage = () => {
     }
     setIsEditing(null)
     setEditText("")
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>, id: string) => {
+    if (event.key === "Enter") {
+      handleEndEdit(id)
+    } else if (event.key === "Escape") {
+      setIsEditing(null)
+      setEditText("")
+    }
   }
 
   const handleDeleteClick = (id: string) => {
@@ -155,6 +164,7 @@ const HomePage = () => {
                   value={editText}
                   onChange={handleEditChange}
                   onBlur={() => handleEndEdit(todo.id)}
+                  onKeyDown={(e) => handleKeyDown(e, todo.id)}
                   autoFocus={true}
                 />
               ) : (


### PR DESCRIPTION
# 概要
- todoのtitleを更新する際のキーイベントを追加
  - `Enter`キーで更新を確定
  - `Escape`キーで更新をキャンセル
 
## コミット詳細
- `src/hooks/useMutateTodo.ts` に、todoのmutation関連のロジックをカスタムフック化
- todoのtitleを更新する際のキーイベントを追加