### PR TITLE
todoの文字数制限のバリデーションを追加

### DIFF
--- a/src/components/atoms/TodoAddInput.tsx
+++ b/src/components/atoms/TodoAddInput.tsx
@@ -10,9 +10,18 @@ export const TodoAddInput = () => {
   const [isLoading, setIsLoading] = useState(false)
   const { createTodoMutation } = useMutateTodo()
 
+  const isValidLength = (title: string) => {
+    const maxLength = 9
+    return title.length <= maxLength
+  }
+
   const handleCreateTodo = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (title.trim() === "") {
+      return
+    }
+    if (!isValidLength(title)) {
+      alert("9文字以内で入力してください。")
       return
     }
     setIsLoading(true)

--- a/src/components/atoms/TodoAddInput.tsx
+++ b/src/components/atoms/TodoAddInput.tsx
@@ -21,7 +21,7 @@ export const TodoAddInput = () => {
       return
     }
     if (!isValidLength(title)) {
-      alert("9文字以内で入力してください。")
+      alert("10文字以下で入力してください。")
       return
     }
     setIsLoading(true)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,7 +58,7 @@ const HomePage = () => {
         console.error("An error occurred during mutation: ", error)
       })
     } else if (!isValidLength(editText)) {
-      alert("9文字以内で入力してください。")
+      alert("10文字以下で入力してください。")
     }
     setEditingTodoId(null)
     setEditText("")

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,20 +46,23 @@ const HomePage = () => {
     setEditText(event.target.value)
   }
 
+  const isValidLength = (title: string) => {
+    const maxLength = 9
+    return title.length <= maxLength
+  }
+
   const handleEndEdit = (id: string) => {
     setLoadingFlags((flags) => ({ ...flags, [id]: true }))
-    if (editText.trim() !== "") {
-      updateTitleMutation
-        .mutateAsync({ id, title: editText })
-        .catch((error) => {
-          console.error("An error occurred during mutation: ", error)
-        })
-        .finally(() => {
-          setLoadingFlags((flags) => ({ ...flags, [id]: false }))
-        })
+    if (editText.trim() !== "" && isValidLength(editText)) {
+      updateTitleMutation.mutateAsync({ id, title: editText }).catch((error) => {
+        console.error("An error occurred during mutation: ", error)
+      })
+    } else if (!isValidLength(editText)) {
+      alert("9文字以内で入力してください。")
     }
     setEditingTodoId(null)
     setEditText("")
+    setLoadingFlags((flags) => ({ ...flags, [id]: false }))
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>, id: string) => {


### PR DESCRIPTION
# 概要
todo作成時とtodo編集時に文字数の制限がない状態でした。
todoリストのスタイル崩れを防ぐために、10文字以上の入力ができないようにバリデーションを追加しました。
バリデーションによるエラーメッセージは簡易的にalertを表示するように実装しました。

## コミット詳細
- todo登録時とtodo編集時にバリデーションを追加しエラーメッセージを表示するように実装
- alertのメッセージ文章を修正