### PR TITLE
title検索時とisCompletedフィルタリング時のバグを修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -91,10 +91,12 @@ const HomePage = () => {
 
   const handleFilterChange = (event: ChangeEvent<HTMLSelectElement>) => {
     setFilter(event.target.value)
+    setCurrentPage(1)
   }
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value)
+    setCurrentPage(1)
   }
 
   let filteredData = data


### PR DESCRIPTION
# 概要
todoリストのページネーションが2ページ目以上の状態でtitle文字列検索と`Active` `Done` のフィルタリング操作をした際に対象のtodoが表示されないバグを解消しました。

## コミット概要
それぞれの検索完了後にページネーションを1ページから表示するように変更